### PR TITLE
Propagate removeListener and cancel calls through stream interceptor

### DIFF
--- a/public/content-script.js
+++ b/public/content-script.js
@@ -117,9 +117,11 @@ function injectors(msgSource) {
         };
 
         removeListener(eventType, callback) {
+          this.stream.removeListener(eventType, callback);
         }
 
         cancel() {
+          this.stream.cancel();
         }
       }
 


### PR DESCRIPTION
Calls to removeListener and cancel methods didn't use to work when the devtools interceptor was registered, leading to streams not being cancelled.

This fixes this issue by propagating the calls to the underlying stream.